### PR TITLE
added like feature on the path db/entries/{id}/like

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -472,6 +472,70 @@ fi
 echo ""
 
 # ============================================================================
+echo -e "${CYAN}=== Like Endpoint Tests ===${NC}\n"
+# ============================================================================
+
+# Test: Create entry and like it
+echo -e "  ${YELLOW}Creating test entry for like functionality...${NC}"
+like_test_entry=$(api_request "POST" "/db/entries" "$TOKEN_MEMBER_8" '{
+    "msg": "Test entry for like functionality",
+    "sig": "#8",
+    "email": "max.gabrielsson@gmail.com",
+    "place": "Test Location"
+}')
+http_code=$(echo "$like_test_entry" | grep "HTTP_CODE:" | cut -d: -f2)
+like_test_entry_id=$(echo "$like_test_entry" | sed '/HTTP_CODE:/d' | python3 -c "import sys, json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+
+assert_test "SHOULD create test entry for likes" "200" "$http_code"
+
+if [ ! -z "$like_test_entry_id" ]; then
+    echo -e "  ${GREEN}Created entry ID: $like_test_entry_id${NC}"
+    
+    # Get initial likes count
+    response=$(api_request "GET" "/db/entries/$like_test_entry_id" "")
+    body=$(echo "$response" | sed '/HTTP_CODE:/d')
+    likes_before=$(echo "$body" | python3 -c "import sys, json; print(json.load(sys.stdin)['likes'])" 2>/dev/null)
+    echo -e "  ${CYAN}Initial likes count: $likes_before${NC}"
+    
+    # Like the entry
+    response=$(api_request "POST" "/db/entries/$like_test_entry_id/like" "$TOKEN_MEMBER_8" "")
+    http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+    assert_test "Member #8 SHOULD like the entry" "200" "$http_code"
+    
+    # Verify likes count increased
+    sleep 0.5  # Brief pause
+    response=$(api_request "GET" "/db/entries/$like_test_entry_id" "")
+    body=$(echo "$response" | sed '/HTTP_CODE:/d')
+    likes_after=$(echo "$body" | python3 -c "import sys, json; print(json.load(sys.stdin)['likes'])" 2>/dev/null)
+    echo -e "  ${CYAN}Likes count after like: $likes_after${NC}"
+    
+    expected_likes=$((likes_before + 1))
+    assert_field "Likes count should increase by 1" "likes" "$expected_likes" "$likes_after"
+    
+    # Test: Unauthenticated user cannot like
+    response=$(api_request "POST" "/db/entries/$like_test_entry_id/like" "" "")
+    http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+    assert_test "Unauthenticated user should NOT like entry" "401" "$http_code"
+    
+    # Test: Another member can like the same entry
+    response=$(api_request "POST" "/db/entries/$like_test_entry_id/like" "$TOKEN_MEMBER_7" "")
+    http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+    assert_test "Member #7 SHOULD like the entry" "200" "$http_code"
+    
+    # Verify likes count increased again
+    sleep 0.5
+    response=$(api_request "GET" "/db/entries/$like_test_entry_id" "")
+    body=$(echo "$response" | sed '/HTTP_CODE:/d')
+    likes_final=$(echo "$body" | python3 -c "import sys, json; print(json.load(sys.stdin)['likes'])" 2>/dev/null)
+    echo -e "  ${CYAN}Final likes count: $likes_final${NC}"
+    
+    expected_final=$((expected_likes + 1))
+    assert_field "Likes count should be 2 after two likes" "likes" "$expected_final" "$likes_final"
+fi
+
+echo ""
+
+# ============================================================================
 echo -e "${CYAN}=== Cleanup Created Entries ===${NC}\n"
 # ============================================================================
 
@@ -497,6 +561,12 @@ if [ ! -z "$restricted_entry_id" ]; then
     docker exec sidan_sql mysql -uroot -pdbpassword dbschema -e "DELETE FROM cl2003_permissions WHERE id=$restricted_entry_id" 2>/dev/null
     docker exec sidan_sql mysql -uroot -pdbpassword dbschema -e "DELETE FROM cl2003_msgs WHERE id=$restricted_entry_id" 2>/dev/null
     echo -e "${GREEN}✓${NC} Cleaned up restricted entry (ID: $restricted_entry_id)"
+fi
+
+if [ ! -z "$like_test_entry_id" ]; then
+    docker exec sidan_sql mysql -uroot -pdbpassword dbschema -e "DELETE FROM 2003_likes WHERE id=$like_test_entry_id" 2>/dev/null
+    docker exec sidan_sql mysql -uroot -pdbpassword dbschema -e "DELETE FROM cl2003_msgs WHERE id=$like_test_entry_id" 2>/dev/null
+    echo -e "${GREEN}✓${NC} Cleaned up like test entry (ID: $like_test_entry_id)"
 fi
 
 echo ""

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -500,7 +500,7 @@ if [ ! -z "$like_test_entry_id" ]; then
     # Like the entry
     response=$(api_request "POST" "/db/entries/$like_test_entry_id/like" "$TOKEN_MEMBER_8" "")
     http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
-    assert_test "Member #8 SHOULD like the entry" "200" "$http_code"
+    assert_test "Member #8 SHOULD like the entry" "204" "$http_code"
     
     # Verify likes count increased
     sleep 0.5  # Brief pause
@@ -520,7 +520,7 @@ if [ ! -z "$like_test_entry_id" ]; then
     # Test: Another member can like the same entry
     response=$(api_request "POST" "/db/entries/$like_test_entry_id/like" "$TOKEN_MEMBER_7" "")
     http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
-    assert_test "Member #7 SHOULD like the entry" "200" "$http_code"
+    assert_test "Member #7 SHOULD like the entry" "204" "$http_code"
     
     # Verify likes count increased again
     sleep 0.5

--- a/src/data/commondb/entry.go
+++ b/src/data/commondb/entry.go
@@ -103,14 +103,14 @@ func (d *CommonDatabase) DeleteEntry(entry *models.Entry) (*models.Entry, error)
 	return entry, nil
 }
 
-func (d *CommonDatabase) LikeEntry(entryId int64, sig string) error {
+func (d *CommonDatabase) LikeEntry(entryId int64, sig string, host string) error {
 	now := time.Now()
 	like := map[string]interface{}{
 		"date": now.Format("2006-01-02"),
 		"time": now.Format("15:04:05"),
 		"id":   entryId,
 		"sig":  sig,
-		"host": "",
+		"host": host,
 	}
 	result := d.DB.Table("2003_likes").Create(like)
 	return result.Error

--- a/src/data/commondb/entry.go
+++ b/src/data/commondb/entry.go
@@ -102,3 +102,16 @@ func (d *CommonDatabase) DeleteEntry(entry *models.Entry) (*models.Entry, error)
 	}
 	return entry, nil
 }
+
+func (d *CommonDatabase) LikeEntry(entryId int64, sig string) error {
+	now := time.Now()
+	like := map[string]interface{}{
+		"date": now.Format("2006-01-02"),
+		"time": now.Format("15:04:05"),
+		"id":   entryId,
+		"sig":  sig,
+		"host": "",
+	}
+	result := d.DB.Table("2003_likes").Create(like)
+	return result.Error
+}

--- a/src/data/database.go
+++ b/src/data/database.go
@@ -29,6 +29,7 @@ type Database interface {
 	ReadEntries(take int, skip int) ([]models.Entry, error)
 	UpdateEntry(entry *models.Entry) (*models.Entry, error)
 	DeleteEntry(entry *models.Entry) (*models.Entry, error)
+	LikeEntry(entryId int64, sig string) error
 
 	CreateMember(member *models.Member) (*models.Member, error)
 	ReadMember(id int64) (*models.Member, error)

--- a/src/data/database.go
+++ b/src/data/database.go
@@ -29,7 +29,7 @@ type Database interface {
 	ReadEntries(take int, skip int) ([]models.Entry, error)
 	UpdateEntry(entry *models.Entry) (*models.Entry, error)
 	DeleteEntry(entry *models.Entry) (*models.Entry, error)
-	LikeEntry(entryId int64, sig string) error
+	LikeEntry(entryId int64, sig string, host string) error
 
 	CreateMember(member *models.Member) (*models.Member, error)
 	ReadMember(id int64) (*models.Member, error)

--- a/src/data/mysqldb/entry.go
+++ b/src/data/mysqldb/entry.go
@@ -23,3 +23,7 @@ func (d *MySQLDatabase) UpdateEntry(entry *models.Entry) (*models.Entry, error) 
 func (d *MySQLDatabase) DeleteEntry(entry *models.Entry) (*models.Entry, error) {
 	return d.CommonDB.DeleteEntry(entry)
 }
+
+func (d *MySQLDatabase) LikeEntry(entryId int64, sig string) error {
+	return d.CommonDB.LikeEntry(entryId, sig)
+}

--- a/src/data/mysqldb/entry.go
+++ b/src/data/mysqldb/entry.go
@@ -24,6 +24,6 @@ func (d *MySQLDatabase) DeleteEntry(entry *models.Entry) (*models.Entry, error) 
 	return d.CommonDB.DeleteEntry(entry)
 }
 
-func (d *MySQLDatabase) LikeEntry(entryId int64, sig string) error {
-	return d.CommonDB.LikeEntry(entryId, sig)
+func (d *MySQLDatabase) LikeEntry(entryId int64, sig string, host string) error {
+	return d.CommonDB.LikeEntry(entryId, sig, host)
 }

--- a/src/router/entry.go
+++ b/src/router/entry.go
@@ -135,3 +135,27 @@ func (eh EntryHandler) readAllEntryHandler(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(entries)
 }
+
+func (eh EntryHandler) likeEntryHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, _ := strconv.ParseInt(vars["id"], 10, 64)
+
+	member := auth.GetMember(r)
+	if member == nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+
+	sig := strconv.FormatInt(member.Number, 10)
+	err := eh.db.LikeEntry(id, sig)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf(`{"error":"%v"}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/src/router/entry.go
+++ b/src/router/entry.go
@@ -148,7 +148,8 @@ func (eh EntryHandler) likeEntryHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	sig := strconv.FormatInt(member.Number, 10)
-	err := eh.db.LikeEntry(id, sig)
+	host := r.RemoteAddr
+	err := eh.db.LikeEntry(id, sig, host)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		http.Error(w, fmt.Sprintf(`{"error":"%v"}`, err.Error()), http.StatusInternalServerError)

--- a/src/router/entry.go
+++ b/src/router/entry.go
@@ -156,7 +156,5 @@ func (eh EntryHandler) likeEntryHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -142,6 +142,11 @@ func Mux(db data.Database) http.Handler {
 	r.Handle("/db/entries",
 		authMiddleware.OptionalAuth(http.HandlerFunc(dbEh.readAllEntryHandler)),
 	).Methods("GET", "OPTIONS")
+	r.Handle("/db/entries/{id:[0-9]+}/like",
+		authMiddleware.RequireAuth(
+			http.HandlerFunc(dbEh.likeEntryHandler),
+		),
+	).Methods("POST", "OPTIONS")
 
 	// Member endpoints (with optional auth for read operations)
 	dbMh := NewMemberHandler(db)


### PR DESCRIPTION
This pull request introduces the ability for authenticated users to "like" entries and adds comprehensive integration tests for this new endpoint. The changes span backend functionality, routing, and integration test coverage. Below are the most important changes grouped by theme:

**Backend functionality:**

* Added a new `LikeEntry` method to the `Database` interface and its implementations (`CommonDatabase` and `MySQLDatabase`) to record likes for entries in the `2003_likes` table. [[1]](diffhunk://#diff-5256ba8d5704df26794e3ab0b330734a59c24a3acf716d87343d0563889dfc71R32) [[2]](diffhunk://#diff-fb1686ec8c7f7b7f9b0d77cb9149adfcfa0726fc043e40bb2857d9f9227e7facR105-R117) [[3]](diffhunk://#diff-a89734580ac57374cf5fa26479fc0f161dbadbe7d0e53445394a0600d6eff90cR26-R29)

**API endpoint and routing:**

* Implemented the `/db/entries/{id}/like` POST endpoint, which allows authenticated members to like an entry. Unauthenticated requests are rejected with a 401 error. [[1]](diffhunk://#diff-f8e3861d49ba5a23ffb6c0154487fc6ba30e18bdeb7d1c32ad8affc2fc6ddbceR138-R161) [[2]](diffhunk://#diff-1c951403937869c948e2344689e9bd9a6706bcc6ce3e2db78975518fd4055eedR145-R149)

**Integration tests:**

* Added integration tests for the like functionality, including creating a test entry, liking it with different members, verifying the likes count increases, and ensuring unauthenticated users cannot like entries.

**Test cleanup:**

* Updated test cleanup logic to remove test entries and their associated likes from the database after tests run.