### PR TITLE
Use where statements where possible to utilize index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.2
 	github.com/rs/cors v1.9.0
-	github.com/sebastiw/go-rsql-mysql v0.0.0
+	github.com/sebastiw/go-rsql-mysql v0.0.0-20260121215516-2e9f902553be
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	gorm.io/driver/mysql v1.5.7
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.30.0
 )
 
@@ -32,7 +34,6 @@ require (
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
@@ -41,7 +42,6 @@ require (
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gorm.io/driver/sqlite v1.6.0 // indirect
 )
 
 replace github.com/sebastiw/go-rsql-mysql => github.com/sebastiw/go-rsql-mysql v0.0.0-20260118190419-633fc825b223

--- a/go.sum
+++ b/go.sum
@@ -188,7 +188,6 @@ github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
@@ -331,8 +330,6 @@ gorm.io/driver/mysql v1.5.7/go.mod h1:sEtPWMiqiN1N1cMXoXmBbd8C6/l+TESwriotuRRpkD
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
 gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
-gorm.io/gorm v1.26.1 h1:ghB2gUI9FkS46luZtn6DLZ0f6ooBJ5IbVej2ENFDjRw=
-gorm.io/gorm v1.26.1/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 gorm.io/gorm v1.30.0 h1:qbT5aPv1UH8gI99OsRlvDToLxW5zR7FzS9acZDOZcgs=
 gorm.io/gorm v1.30.0/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/src/data/commondb/rsql_split.go
+++ b/src/data/commondb/rsql_split.go
@@ -1,0 +1,61 @@
+package commondb
+
+import "strings"
+
+// SplitWhereHaving splits SQL conditions into WHERE (regular fields) and HAVING (aggregates)
+func SplitWhereHaving(sqlCondition string) (whereClause, havingClause string) {
+	sqlCondition = strings.TrimSpace(sqlCondition)
+	if strings.HasPrefix(sqlCondition, "(") && strings.HasSuffix(sqlCondition, ")") {
+		sqlCondition = sqlCondition[1 : len(sqlCondition)-1]
+	}
+
+	var whereParts, havingParts []string
+	for _, part := range splitOnAND(sqlCondition) {
+		if part = strings.TrimSpace(part); part == "" {
+			continue
+		}
+		if strings.Contains(part, "COUNT(") {
+			havingParts = append(havingParts, part)
+		} else {
+			whereParts = append(whereParts, part)
+		}
+	}
+
+	if len(whereParts) > 0 {
+		whereClause = strings.Join(whereParts, " AND ")
+	}
+	if len(havingParts) > 0 {
+		havingClause = strings.Join(havingParts, " AND ")
+	}
+	return
+}
+
+func splitOnAND(condition string) []string {
+	var parts []string
+	var current strings.Builder
+	parenDepth := 0
+
+	for i := 0; i < len(condition); i++ {
+		switch condition[i] {
+		case '(':
+			parenDepth++
+			current.WriteByte(condition[i])
+		case ')':
+			parenDepth--
+			current.WriteByte(condition[i])
+		default:
+			if parenDepth == 0 && i+5 <= len(condition) && condition[i:i+5] == " AND " {
+				parts = append(parts, current.String())
+				current.Reset()
+				i += 4
+			} else {
+				current.WriteByte(condition[i])
+			}
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
+}

--- a/src/data/commondb/rsql_split_test.go
+++ b/src/data/commondb/rsql_split_test.go
@@ -1,0 +1,138 @@
+package commondb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitWhereHaving(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectWhere   string
+		expectHaving  string
+	}{
+		{
+			name:         "aggregate only",
+			input:        "COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5",
+			expectWhere:  "",
+			expectHaving: "COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5",
+		},
+		{
+			name:         "regular field only",
+			input:        `cl2003_msgs.sig = "Alice"`,
+			expectWhere:  `cl2003_msgs.sig = "Alice"`,
+			expectHaving: "",
+		},
+		{
+			name:         "joined table field",
+			input:        "SideKicks.number = 123",
+			expectWhere:  "SideKicks.number = 123",
+			expectHaving: "",
+		},
+		{
+			name:         "mixed aggregate and regular",
+			input:        `(COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 3 AND cl2003_msgs.sig = "Alice")`,
+			expectWhere:  `cl2003_msgs.sig = "Alice"`,
+			expectHaving: "COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 3",
+		},
+		{
+			name:         "multiple regular fields",
+			input:        `(cl2003_msgs.sig = "Alice" AND cl2003_msgs.msg = "beer")`,
+			expectWhere:  `cl2003_msgs.sig = "Alice" AND cl2003_msgs.msg = "beer"`,
+			expectHaving: "",
+		},
+		{
+			name:         "mixed with joined table",
+			input:        `(SideKicks.number = 123 AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5)`,
+			expectWhere:  "SideKicks.number = 123",
+			expectHaving: "COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5",
+		},
+		{
+			name:         "complex with multiple conditions",
+			input:        `(cl2003_msgs.sig = "Alice" AND SideKicks.number = 123 AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5)`,
+			expectWhere:  "cl2003_msgs.sig = \"Alice\" AND SideKicks.number = 123",
+			expectHaving: "COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5",
+		},
+		{
+			name:         "OR with aggregate - entire condition goes to HAVING",
+			input:        `(SideKicks.number IN (7,8,9) OR (COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5 AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) < 15))`,
+			expectWhere:  "",
+			expectHaving: "SideKicks.number IN (7,8,9) OR (COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5 AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) < 15)",
+		},
+		{
+			name:         "complex OR with mixed AND - all to HAVING when aggregate present",
+			input:        `((SideKicks.number IN (7,8,9) AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5) OR (SideKicks.number NOT IN (7,8,9) AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) < 5))`,
+			expectWhere:  "",
+			expectHaving: "(SideKicks.number IN (7,8,9) AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5) OR (SideKicks.number NOT IN (7,8,9) AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) < 5)",
+		},
+		{
+			name:         "nested OR inside AND with regular fields - should split",
+			input:        `(cl2003_msgs.sig = "Alice" AND (cl2003_msgs.msg = "beer" OR cl2003_msgs.msg = "wine"))`,
+			expectWhere:  `cl2003_msgs.sig = "Alice" AND (cl2003_msgs.msg = "beer" OR cl2003_msgs.msg = "wine")`,
+			expectHaving: "",
+		},
+		{
+			name:         "multiple aggregates AND condition - all to HAVING",
+			input:        `(COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5 AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) < 10)`,
+			expectWhere:  "",
+			expectHaving: "COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) > 5 AND COUNT(DISTINCT CONCAT(LikeRecords.sig, '|', LikeRecords.host)) < 10",
+		},
+		{
+			name:         "complex nested regular fields only - all to WHERE",
+			input:        `((cl2003_msgs.sig = "Alice" OR cl2003_msgs.sig = "Bob") AND cl2003_msgs.msg = "test")`,
+			expectWhere:  `(cl2003_msgs.sig = "Alice" OR cl2003_msgs.sig = "Bob") AND cl2003_msgs.msg = "test"`,
+			expectHaving: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			where, having := SplitWhereHaving(tt.input)
+			assert.Equal(t, tt.expectWhere, where, "WHERE clause mismatch")
+			assert.Equal(t, tt.expectHaving, having, "HAVING clause mismatch")
+		})
+	}
+}
+
+func TestSplitOnAND(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single condition",
+			input:    `sig = "Alice"`,
+			expected: []string{`sig = "Alice"`},
+		},
+		{
+			name:     "two conditions",
+			input:    `sig = "Alice" AND likes > 5`,
+			expected: []string{`sig = "Alice"`, `likes > 5`},
+		},
+		{
+			name:     "three conditions",
+			input:    `sig = "Alice" AND likes > 5 AND msg = "beer"`,
+			expected: []string{`sig = "Alice"`, `likes > 5`, `msg = "beer"`},
+		},
+		{
+			name:     "nested parentheses",
+			input:    `(sig = "Alice" AND likes > 5) AND msg = "beer"`,
+			expected: []string{`(sig = "Alice" AND likes > 5)`, `msg = "beer"`},
+		},
+		{
+			name:     "function with AND inside",
+			input:    `CONCAT(sig, ' AND ', host) = "test" AND likes > 5`,
+			expected: []string{`CONCAT(sig, ' AND ', host) = "test"`, `likes > 5`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitOnAND(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
When using WHERE mysql utlizes the indexes created, in having it does not.

When the where statement from the rsql parser includes an aggregate function COUNT( then that statements need to go in the having clause, otherwise it can go in the where clause.

