### PR TITLE
Gemini command auth, generated with gemini 3 preview

### DIFF
--- a/cmd/sidan-auth/main.go
+++ b/cmd/sidan-auth/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const defaultAPI = "https://api.chalmerslosers.com"
+
+type DeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Error       string `json:"error"`
+}
+
+func main() {
+	apiURL := flag.String("api", defaultAPI, "API URL")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 || args[0] != "token" || args[1] != "add" {
+		fmt.Println("Usage: sidan-auth [options] token add")
+		os.Exit(1)
+	}
+
+	fmt.Printf("[add token using %s/auth]\n", *apiURL)
+
+	// 1. Request Device Code
+	resp, err := http.Post(*apiURL+"/auth/device/code", "application/json", nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error contacting API: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "API Error (%d): %s\n", resp.StatusCode, string(body))
+		os.Exit(1)
+	}
+
+	var deviceResp DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+		fmt.Fprintf(os.Stderr, "Error decoding response: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Activation URL:\n%s?code=%s\n", deviceResp.VerificationURI, deviceResp.UserCode)
+	// Or use VerificationURIComplete if we want to be nicer, but prompts user code separate
+	// The prompt example showed: https://.../auth/device?code=...
+	
+	interval := time.Duration(deviceResp.Interval) * time.Second
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+
+	// 2. Poll for Token
+	fmt.Println("\nWaiting for approval...")
+	
+	client := &http.Client{}
+	
+	for {
+		time.Sleep(interval)
+
+	
+tokenReq := map[string]string{
+			"device_code": deviceResp.DeviceCode,
+		}
+		jsonBody, _ := json.Marshal(tokenReq)
+
+		req, _ := http.NewRequest("POST", *apiURL+"/auth/device/token", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+
+	
+tokenResp, err := client.Do(req)
+		if err != nil {
+			fmt.Printf(".")
+			continue
+		}
+		defer tokenResp.Body.Close()
+
+		if tokenResp.StatusCode == 200 {
+			var tokenData TokenResponse
+			if err := json.NewDecoder(tokenResp.Body).Decode(&tokenData); err != nil {
+				fmt.Fprintf(os.Stderr, "\nError decoding token: %v\n", err)
+				os.Exit(1)
+			}
+			
+			saveToken(tokenData)
+			fmt.Println("\nSuccess! Token saved.")
+			return
+		}
+
+		var errData TokenResponse
+		json.NewDecoder(tokenResp.Body).Decode(&errData)
+		
+		if errData.Error == "authorization_pending" {
+			// Continue polling
+		} else if errData.Error == "slow_down" {
+			interval += 5 * time.Second
+		} else if errData.Error == "access_denied" {
+			fmt.Println("\nAccess denied by user.")
+			os.Exit(1)
+		} else if errData.Error == "expired_token" {
+			fmt.Println("\nSession expired. Please try again.")
+			os.Exit(1)
+		} else {
+			fmt.Printf("\nError: %s\n", errData.Error)
+			os.Exit(1)
+		}
+	}
+}
+
+func saveToken(token TokenResponse) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not find home directory: %v\n", err)
+		return
+	}
+
+	configDir := filepath.Join(home, ".sidan")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not create config directory: %v\n", err)
+		return
+	}
+
+	configFile := filepath.Join(configDir, "config.yaml")
+	
+	// Simple YAML/JSON write
+	// We preserve existing config if possible? 
+	// For MVP, just append or overwrite specific key is hard without a parser.
+	// We'll write a simple file. 
+	
+	file, err := os.Create(configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not create config file: %v\n", err)
+		return
+	}
+	defer file.Close()
+	
+	// Writing simple YAML
+	fmt.Fprintf(file, "access_token: %s\n", token.AccessToken)
+	fmt.Fprintf(file, "token_type: %s\n", token.TokenType)
+	fmt.Fprintf(file, "expires_in: %d\n", token.ExpiresIn)
+	
+	fmt.Printf("Token written to %s\n", configFile)
+}

--- a/db/2026-01-25-device-auth-tables.sql
+++ b/db/2026-01-25-device-auth-tables.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `device_auth_states` (
+  `device_code` varchar(64) NOT NULL,
+  `user_code` varchar(32) NOT NULL,
+  `status` varchar(16) NOT NULL DEFAULT 'pending',
+  `member_number` bigint(20) DEFAULT NULL,
+  `scopes` text,
+  `created_at` datetime(3) DEFAULT NULL,
+  `expires_at` datetime(3) NOT NULL,
+  `last_checked` datetime(3) DEFAULT NULL,
+  PRIMARY KEY (`device_code`),
+  UNIQUE KEY `idx_device_auth_states_user_code` (`user_code`),
+  KEY `idx_device_auth_states_expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.2
 	github.com/rs/cors v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/src/data/commondb/auth.go
+++ b/src/data/commondb/auth.go
@@ -39,3 +39,45 @@ func (d *CommonDatabase) CleanupExpiredAuthStates() error {
 	result := d.DB.Where("expires_at < ?", time.Now()).Delete(&models.AuthState{})
 	return result.Error
 }
+
+// Device Auth operations
+
+func (d *CommonDatabase) CreateDeviceAuthState(state *models.DeviceAuthState) error {
+	result := d.DB.Create(state)
+	return result.Error
+}
+
+func (d *CommonDatabase) GetDeviceAuthStateByDeviceCode(code string) (*models.DeviceAuthState, error) {
+	var state models.DeviceAuthState
+	result := d.DB.Where("device_code = ?", code).First(&state)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	
+	// Check if expired
+	if state.ExpiresAt.Before(time.Now()) {
+		// Don't delete immediately, let cleanup job handle it or handle it in handler
+		return nil, errors.New("state expired")
+	}
+	
+	return &state, nil
+}
+
+func (d *CommonDatabase) GetDeviceAuthStateByUserCode(code string) (*models.DeviceAuthState, error) {
+	var state models.DeviceAuthState
+	result := d.DB.Where("user_code = ?", code).First(&state)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	
+	if state.ExpiresAt.Before(time.Now()) {
+		return nil, errors.New("state expired")
+	}
+	
+	return &state, nil
+}
+
+func (d *CommonDatabase) UpdateDeviceAuthState(state *models.DeviceAuthState) error {
+	result := d.DB.Save(state)
+	return result.Error
+}

--- a/src/data/database.go
+++ b/src/data/database.go
@@ -55,6 +55,12 @@ type Database interface {
 	GetAuthState(id string) (*models.AuthState, error)
 	DeleteAuthState(id string) error
 	CleanupExpiredAuthStates() error
+
+	// Device Auth operations
+	CreateDeviceAuthState(state *models.DeviceAuthState) error
+	GetDeviceAuthStateByDeviceCode(code string) (*models.DeviceAuthState, error)
+	GetDeviceAuthStateByUserCode(code string) (*models.DeviceAuthState, error)
+	UpdateDeviceAuthState(state *models.DeviceAuthState) error
 }
 
 func NewDatabase() (Database, error) {

--- a/src/data/mysqldb/db.go
+++ b/src/data/mysqldb/db.go
@@ -116,3 +116,21 @@ func (d *MySQLDatabase) DeleteAuthState(id string) error {
 func (d *MySQLDatabase) CleanupExpiredAuthStates() error {
 	return d.CommonDB.CleanupExpiredAuthStates()
 }
+
+// Device Auth operations - delegated to CommonDB
+
+func (d *MySQLDatabase) CreateDeviceAuthState(state *models.DeviceAuthState) error {
+	return d.CommonDB.CreateDeviceAuthState(state)
+}
+
+func (d *MySQLDatabase) GetDeviceAuthStateByDeviceCode(code string) (*models.DeviceAuthState, error) {
+	return d.CommonDB.GetDeviceAuthStateByDeviceCode(code)
+}
+
+func (d *MySQLDatabase) GetDeviceAuthStateByUserCode(code string) (*models.DeviceAuthState, error) {
+	return d.CommonDB.GetDeviceAuthStateByUserCode(code)
+}
+
+func (d *MySQLDatabase) UpdateDeviceAuthState(state *models.DeviceAuthState) error {
+	return d.CommonDB.UpdateDeviceAuthState(state)
+}

--- a/src/models/auth.go
+++ b/src/models/auth.go
@@ -18,3 +18,19 @@ type AuthState struct {
 func (AuthState) TableName() string {
 	return "auth_states"
 }
+
+// DeviceAuthState represents device authorization flow state
+type DeviceAuthState struct {
+	DeviceCode  string    `gorm:"primaryKey;size:64" json:"device_code"`
+	UserCode    string    `gorm:"uniqueIndex;size:32;not null" json:"user_code"`
+	Status      string    `gorm:"size:16;not null;default:'pending'" json:"status"` // pending, approved, denied
+	MemberNumber *int64    `json:"member_number,omitempty"` // Nullable
+	Scopes      string    `gorm:"type:text" json:"scopes"` // JSON or comma-separated
+	CreatedAt   time.Time `json:"created_at"`
+	ExpiresAt   time.Time `gorm:"not null;index" json:"expires_at"`
+	LastChecked time.Time `json:"last_checked"`
+}
+
+func (DeviceAuthState) TableName() string {
+	return "device_auth_states"
+}

--- a/src/router/device_auth.go
+++ b/src/router/device_auth.go
@@ -1,0 +1,308 @@
+package router
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sebastiw/sidan-backend/src/auth"
+	"github.com/sebastiw/sidan-backend/src/config"
+	"github.com/sebastiw/sidan-backend/src/models"
+)
+
+// GenerateUserCode creates a short, readable code (e.g., ABCD-1234)
+func generateUserCode() (string, error) {
+	b := make([]byte, 5) // 5 bytes = 40 bits. Base32 is 5 bits/char -> 8 chars
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	str := base32.StdEncoding.EncodeToString(b)
+	return fmt.Sprintf("%s-%s", str[:4], str[4:8]), nil
+}
+
+// DeviceInit initiates the device authorization flow
+// POST /auth/device/code
+func (h *AuthHandler) DeviceInit(w http.ResponseWriter, r *http.Request) {
+	// Generate codes
+	deviceCode := uuid.New().String()
+	userCode, err := generateUserCode()
+	if err != nil {
+		slog.Error("failed to generate user code", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Store in DB
+	state := &models.DeviceAuthState{
+		DeviceCode: deviceCode,
+		UserCode:   userCode,
+		Status:     "pending",
+		ExpiresAt:  time.Now().Add(15 * time.Minute),
+		CreatedAt:  time.Now(),
+		LastChecked: time.Now(),
+	}
+
+	if err := h.db.CreateDeviceAuthState(state); err != nil {
+		slog.Error("failed to create device auth state", "error", err)
+		http.Error(w, "database error", http.StatusInternalServerError)
+		return
+	}
+
+	// Return response (RFC 8628 style)
+	host := config.GetServer().Host // e.g., "api.chalmerslosers.com" - might need to check how to get public URL
+	// If config Host doesn't include protocol/port, we might need to construct it.
+	// Assuming config has enough or we infer from request?
+	// The example output uses "https://api.chalmerslosers.com/auth/device"
+	// I'll assume I can construct it relative or use config.
+	
+	// For now, construct verification URI
+	verificationURI := fmt.Sprintf("https://%s/auth/device", r.Host) // Using request host is often safer if behind proxy
+
+	resp := map[string]interface{}{
+		"device_code":      deviceCode,
+		"user_code":        userCode,
+		"verification_uri": verificationURI,
+		"verification_uri_complete": fmt.Sprintf("%s?code=%s", verificationURI, userCode),
+		"expires_in":       900, // 15 minutes
+		"interval":         5,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// DeviceToken polls for the token
+// POST /auth/device/token
+func (h *AuthHandler) DeviceToken(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DeviceCode string `json:"device_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	state, err := h.db.GetDeviceAuthStateByDeviceCode(req.DeviceCode)
+	if err != nil {
+		http.Error(w, "invalid_grant", http.StatusBadRequest) // or expired
+		return
+	}
+
+	switch state.Status {
+	case "pending":
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest) // RFC says 400 for authorization_pending
+		json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+		return
+	case "denied":
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "access_denied"})
+		return
+	case "approved":
+		// Issue Token
+		if state.MemberNumber == nil {
+			slog.Error("approved state missing member number")
+			http.Error(w, "server_error", http.StatusInternalServerError)
+			return
+		}
+
+		member, err := h.db.ReadMemberByNumber(*state.MemberNumber)
+		if err != nil {
+			http.Error(w, "server_error", http.StatusInternalServerError)
+			return
+		}
+
+		// Use stored scopes or default
+		scopes := getScopesForMemberType(member)
+		
+		// Generate JWT
+		// We use "device" as provider or maybe "sidan-auth"
+		jwtToken, err := auth.GenerateJWT(member.Number, *member.Email, scopes, "sidan-cli", config.GetJWTSecret())
+		if err != nil {
+			http.Error(w, "server_error", http.StatusInternalServerError)
+			return
+		}
+
+		// Delete state (single use)
+		// Or maybe keep it to prevent replay? But device code flow usually allows refresh tokens.
+		// For MVP, we just return the Access Token.
+		// Ideally we should delete or mark as used.
+		// Let's mark as used/completed to avoid reuse if we want strictness.
+		// h.db.DeleteDeviceAuthState... (Not implemented yet, but Update works)
+		state.Status = "completed"
+		h.db.UpdateDeviceAuthState(state)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": jwtToken,
+			"token_type":   "Bearer",
+			"expires_in":   28800,
+		})
+		return
+	default:
+		http.Error(w, "invalid_grant", http.StatusBadRequest)
+		return
+	}
+}
+
+// DeviceVerifyPage renders the verification UI
+// GET /auth/device
+func (h *AuthHandler) DeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	
+	// Simple HTML UI
+	html := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Device Activation</title>
+    <style>
+        body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; background: #f0f0f0; }
+        .card { background: white; padding: 2rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); max-width: 400px; width: 100%%; text-align: center; }
+        input { font-size: 1.5rem; letter-spacing: 0.2rem; text-align: center; width: 100%%; padding: 0.5rem; margin: 1rem 0; text-transform: uppercase; }
+        button { background: #007bff; color: white; border: none; padding: 0.75rem 1.5rem; font-size: 1rem; border-radius: 4px; cursor: pointer; width: 100%%; }
+        button:disabled { background: #ccc; }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+    <div class="card" id="app">
+        <h2>Connect Device</h2>
+        <p>Enter the code displayed on your device</p>
+        <input type="text" id="code" value="%s" placeholder="ABCD-1234" maxlength="9">
+        <div id="status"></div>
+        <button id="btn" onclick="verify()">Connect</button>
+    </div>
+    <script>
+        const codeInput = document.getElementById('code');
+        const btn = document.getElementById('btn');
+        const status = document.getElementById('status');
+
+        // Check if logged in (check for token in URL hash if just redirected, or localStorage)
+        // Since we don't have cookies, we need to handle auth flow here.
+        
+        let token = localStorage.getItem('sidan_token');
+        
+        // Handle redirect from login
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('token')) {
+            const tokenData = JSON.parse(params.get('token'));
+            token = tokenData.access_token;
+            localStorage.setItem('sidan_token', token);
+            // Clean URL
+            window.history.replaceState({}, document.title, window.location.pathname + (codeInput.value ? '?code='+codeInput.value : ''));
+        }
+
+        async function checkLogin() {
+            if (!token) {
+                btn.innerText = "Log in to Continue";
+                btn.onclick = () => {
+                     // Redirect to login, with callback to here
+                     const currentUrl = window.location.href;
+                     // We need to pass redirect_uri to /auth/login
+                     // The login handler expects redirect_uri
+                     window.location.href = '/auth/login?provider=google&redirect_uri=' + encodeURIComponent(window.location.protocol + '//' + window.location.host + window.location.pathname + '?code=' + codeInput.value);
+                };
+                return false;
+            }
+            return true;
+        }
+
+        async function verify() {
+            if (!await checkLogin()) return;
+
+            const code = codeInput.value;
+            if (!code) return;
+
+            btn.disabled = true;
+            btn.innerText = "Verifying...";
+
+            try {
+                const res = await fetch('/auth/device/verify', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + token
+                    },
+                    body: JSON.stringify({ user_code: code })
+                });
+
+                if (res.ok) {
+                    document.getElementById('app').innerHTML = '<h2>Success!</h2><p>You can now return to your device.</p>';
+                } else {
+                    const data = await res.json();
+                    status.innerText = data.error || 'Error verifying code';
+                    status.style.color = 'red';
+                    btn.disabled = false;
+                    btn.innerText = "Connect";
+                }
+            } catch (e) {
+                status.innerText = 'Network error';
+                btn.disabled = false;
+                btn.innerText = "Connect";
+            }
+        }
+
+        checkLogin();
+    </script>
+</body>
+</html>
+	`, code)
+	w.Header().Set("Content-Type", "text/html")
+	w.Write([]byte(html))
+}
+
+// DeviceVerifyAction handles the approval
+// POST /auth/device/verify
+// Requires Auth
+func (h *AuthHandler) DeviceVerifyAction(w http.ResponseWriter, r *http.Request) {
+    // Get Member from context (set by middleware)
+    member := auth.GetMember(r)
+    if member == nil {
+        http.Error(w, "unauthorized", http.StatusUnauthorized)
+        return
+    }
+
+    var req struct {
+        UserCode string `json:"user_code"`
+    }
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "invalid request", http.StatusBadRequest)
+        return
+    }
+    
+    // Normalize code (uppercase)
+    req.UserCode = strings.ToUpper(req.UserCode)
+
+    state, err := h.db.GetDeviceAuthStateByUserCode(req.UserCode)
+    if err != nil {
+        http.Error(w, "invalid code", http.StatusBadRequest)
+        return
+    }
+    
+    if state.Status != "pending" {
+        http.Error(w, "code already used or expired", http.StatusBadRequest)
+        return
+    }
+
+    // Approve
+    state.Status = "approved"
+    state.MemberNumber = &member.Number
+    // state.Scopes = ... (could store specific scopes requested, for now defaults)
+    
+    if err := h.db.UpdateDeviceAuthState(state); err != nil {
+        http.Error(w, "db error", http.StatusInternalServerError)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(map[string]bool{"success": true})
+}

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -87,6 +87,12 @@ func Mux(db data.Database) http.Handler {
 	authHandler := NewAuthHandler(db)
 	r.HandleFunc("/auth/login", authHandler.Login).Methods("GET", "OPTIONS")
 	r.HandleFunc("/auth/callback", authHandler.Callback).Methods("GET", "OPTIONS")
+
+	// Device Auth handlers
+	r.HandleFunc("/auth/device/code", authHandler.DeviceInit).Methods("POST", "OPTIONS")
+	r.HandleFunc("/auth/device/token", authHandler.DeviceToken).Methods("POST", "OPTIONS")
+	r.HandleFunc("/auth/device", authHandler.DeviceVerifyPage).Methods("GET", "OPTIONS")
+	r.Handle("/auth/device/verify", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.DeviceVerifyAction))).Methods("POST", "OPTIONS")
 	
 	// Auth handlers - authenticated endpoints
 	r.Handle("/auth/session", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.GetSession))).Methods("GET", "OPTIONS")


### PR DESCRIPTION
  Summary of Changes

   1. CLI (`cmd/sidan-auth/`): Created the sidan-auth tool with the token add command. It initiates the handshake, displays the user code, polls for the token, and saves it to ~/.sidan/config.yaml.
   2. Backend Logic (`src/router/device_auth.go`): Implemented the full Device Flow (RFC 8628) within the backend:
       * POST /auth/device/code: Generates device and user codes.
       * POST /auth/device/token: Handles polling and issues JWTs upon approval. * GET /auth/device: Serves a simple, embedded HTML verification page. * POST /auth/device/verify: Handles the user approval action.
   3. Database Support: * Added DeviceAuthState model in src/models/auth.go. * Added methods to Database interface and implemented them in commondb and mysqldb. * Created migration file db/2026-01-25-device-auth-tables.sql.
   4. Router: Registered new endpoints in src/router/router.go.

  Google Console Configuration

  Since this implementation uses the backend as a proxy (the backend handles the "Device Flow" logic while delegating the actual user authentication to Google via the existing Web flow), you do not need to
  enable the "Limited Input Device" flow in Google Console.

  However, you MUST do the following:

   1. Go to the Google Cloud Console > APIs & Services > Credentials.
   2. Select your OAuth 2.0 Client ID.
   3. Add the verification page URL to the Authorized redirect URIs:
       * https://api.chalmerslosers.com/auth/device
       * (Optional for local testing) http://localhost:<PORT>/auth/device

  How to Run

   1. Database Migration: Run the new SQL script against your database.
   1     mysql -u <user> -p <database> < db/2026-01-25-device-auth-tables.sql
   2. Build & Run Backend:
   1     go run src/sidan-backend.go
   3. Use the CLI:

   1     # Build
   2     go build -o sidan-auth cmd/sidan-auth/main.go
   3
   4     # Run (defaults to production URL)
   5     ./sidan-auth token add
   6
   7     # Run (targeting local backend)
   8     ./sidan-auth -api http://localhost:8080 token add