### PR TITLE
oauth2 web auth refresh token

### DIFF
--- a/db/2026-04-03-sessions.sql
+++ b/db/2026-04-03-sessions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS `oauth2_sessions` (
+    `token`         VARCHAR(64)  NOT NULL,
+    `member_number` BIGINT       NOT NULL,
+    `email`         VARCHAR(255) NOT NULL,
+    `provider`      VARCHAR(32)  NOT NULL,
+    `expires_at`    DATETIME     NOT NULL,
+    `created_at`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`token`),
+    INDEX `idx_member_number` (`member_number`),
+    INDEX `idx_expires_at` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -13,12 +13,12 @@ JWT Bearer token authentication with OAuth2 providers. Designed for mobile apps 
 
 **Google Cloud Console** (https://console.cloud.google.com/):
 1. Create OAuth 2.0 Client ID (Web application)
-2. Add redirect URI: `http://localhost:8080/auth/callback` (or your domain)
+2. Add redirect URI: `http://localhost:8080/auth/web/callback` (or your domain)
 3. Copy Client ID and Client Secret
 
 **GitHub** (https://github.com/settings/developers):
 1. Create OAuth App
-2. Authorization callback URL: `http://localhost:8080/auth/callback`
+2. Authorization callback URL: `http://localhost:8080/auth/web/callback`
 3. Copy Client ID and Client Secret
 
 ### 2. Configure Application
@@ -29,12 +29,12 @@ oauth2:
   google:
     clientId: "YOUR_GOOGLE_CLIENT_ID"
     clientSecret: "YOUR_GOOGLE_CLIENT_SECRET"
-    redirectURL: "http://localhost:8080/auth/callback"
+    redirectURL: "http://localhost:8080/auth/web/callback"
     scopes: ["openid", "email", "profile"]
   github:
     clientId: "YOUR_GITHUB_CLIENT_ID"
     clientSecret: "YOUR_GITHUB_CLIENT_SECRET"
-    redirectURL: "http://localhost:8080/auth/callback"
+    redirectURL: "http://localhost:8080/auth/web/callback"
     scopes: ["user:email"]
 ```
 
@@ -58,11 +58,11 @@ go run src/sidan-backend.go
 ## Authentication Flow
 
 ```
-User → /auth/login?provider=google
+User → /auth/web/login?provider=google
   ↓
 Google OAuth2 consent screen
   ↓
-/auth/callback (validates, generates JWT)
+/auth/web/callback (validates, generates JWT)
   ↓
 Returns JWT token in response body
   ↓
@@ -75,16 +75,17 @@ User authenticated ✓
 
 ### Login
 ```
-GET /auth/login?provider=google&redirect_uri=/dashboard
+GET /auth/web/login?provider=google&redirect_uri=/dashboard
 ```
 
 ### Callback (Returns JWT)
 ```
-GET /auth/callback?state=...&code=...
+GET /auth/web/callback?state=...&code=...
 
 Response:
 {
   "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "...",
   "token_type": "Bearer",
   "expires_in": 28800,
   "member": {
@@ -117,7 +118,7 @@ Response:
 
 ### Logout
 ```
-POST /auth/logout
+POST /auth/web/logout
 Authorization: Bearer <token>
 
 Response: {"success": true}
@@ -125,12 +126,15 @@ Response: {"success": true}
 
 ### Refresh Token
 ```
-POST /auth/refresh
-Authorization: Bearer <token>
+POST /auth/web/refresh
+Content-Type: application/json
+
+{"refresh_token": "..."}
 
 Response:
 {
   "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "...",
   "token_type": "Bearer",
   "expires_in": 28800
 }
@@ -168,8 +172,7 @@ Scopes automatically assigned based on member's `isvalid` status.
 ## Database Tables
 
 - `auth_states` - OAuth2 state (CSRF protection, 10min TTL)
-- `auth_tokens` - Encrypted OAuth2 access/refresh tokens
-- `auth_provider_links` - Links OAuth2 accounts to members
+- `oauth2_sessions` - Long-lived refresh tokens (30d TTL)
 
 ## Member Registration
 
@@ -188,10 +191,10 @@ VALUES (9999, 'John Doe', 'john@example.com', true);
 
 - ✅ **PKCE** - Protects against authorization code interception
 - ✅ **State validation** - CSRF protection
-- ✅ **Token encryption** - OAuth2 tokens encrypted with AES-256-GCM at rest
 - ✅ **JWT signatures** - HS256 with 512-bit secret
 - ✅ **Token expiry** - 8-hour JWT lifetime
-- ✅ **Automatic cleanup** - Expired OAuth2 states deleted every 15min
+- ✅ **Refresh token rotation** - Single-use refresh tokens (30d)
+- ✅ **Automatic cleanup** - Expired states and sessions deleted every 15min
 
 ## Client Implementation
 
@@ -199,12 +202,13 @@ VALUES (9999, 'John Doe', 'john@example.com', true);
 
 ```javascript
 // 1. Login - Redirect to OAuth2
-window.location.href = '/auth/login?provider=google'
+window.location.href = '/auth/web/login?provider=google'
 
 // 2. Handle callback - Extract JWT from response
-const response = await fetch('/auth/callback?...')
+const response = await fetch('/auth/web/callback?...')
 const data = await response.json()
 localStorage.setItem('access_token', data.access_token)
+localStorage.setItem('refresh_token', data.refresh_token)
 
 // 3. API requests - Send Bearer token
 const token = localStorage.getItem('access_token')
@@ -212,12 +216,23 @@ const res = await fetch('/db/entries', {
   headers: { 'Authorization': `Bearer ${token}` }
 })
 
-// 4. Logout
-await fetch('/auth/logout', {
+// 4. Refresh token when JWT expires
+const refresh = await fetch('/auth/web/refresh', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ refresh_token: localStorage.getItem('refresh_token') })
+})
+const refreshData = await refresh.json()
+localStorage.setItem('access_token', refreshData.access_token)
+localStorage.setItem('refresh_token', refreshData.refresh_token)
+
+// 5. Logout
+await fetch('/auth/web/logout', {
   method: 'POST',
   headers: { 'Authorization': `Bearer ${token}` }
 })
 localStorage.removeItem('access_token')
+localStorage.removeItem('refresh_token')
 ```
 
 ### Mobile (Swift/Kotlin)
@@ -251,14 +266,13 @@ request.addHeader("Authorization", "Bearer $token")
 **JWT System**: Token generation and validation  
 **OAuth2 Flow**: Provider abstraction (Google, GitHub)  
 **Middleware**: RequireAuth, RequireScope, OptionalAuth  
-**Blacklist**: Token revocation support
+**Session Store**: Refresh token storage in `oauth2_sessions` table
 
 ### Files
 
 ```
 src/auth/
   ├── jwt.go              # JWT sign/verify
-  ├── crypto.go           # OAuth2 token encryption (AES-256-GCM)
   ├── pkce.go             # PKCE verifier/challenge generation
   ├── provider.go         # OAuth2 provider abstraction
   └── middleware.go       # Auth middleware & cleanup
@@ -267,10 +281,10 @@ src/router/
   └── auth.go             # HTTP handlers (login, callback, session, logout, refresh)
 
 src/models/
-  └── auth.go             # Database models (AuthState, AuthToken, JWTBlacklist)
+  └── session.go          # Session model (oauth2_sessions table)
 
 src/data/commondb/
-  └── auth.go             # Database operations
+  └── session.go          # Session CRUD operations
 ```
 
 ## Troubleshooting
@@ -287,12 +301,12 @@ src/data/commondb/
 
 **"token expired"**:
 - JWT lifetime exceeded (8 hours)
-- Use `/auth/refresh` or re-login
+- Use `POST /auth/web/refresh` with a valid refresh token, or re-login
 - Note: Logout does not revoke JWTs (they remain valid until expiry)
 
 **"redirect_uri_mismatch"**:
 - Ensure redirect URI in Google/GitHub console matches config exactly
-- Must be: `http://localhost:8080/auth/callback` (or your domain)
+- Must be: `http://localhost:8080/auth/web/callback` (or your domain)
 
 **"email not registered"**:
 - Member email must exist in `cl2007_members` table
@@ -305,19 +319,10 @@ src/data/commondb/
 ## Production Deployment
 
 1. Set `JWT_SECRET` environment variable (required)
-2. Update OAuth2 redirect URIs to production domain
+2. Update OAuth2 redirect URIs to production domain (`/auth/web/callback`)
 3. Use HTTPS (required for secure tokens)
 4. Update `config/production.yaml` with production settings
 5. Notify users: re-login required after deployment (breaking change)
-
-## Migration from Cookie-Based Auth
-
-**Key Changes**:
-- Cookies → JWT Bearer tokens
-- Server sessions → Client-side tokens
-- `Cookie: session_id` → `Authorization: Bearer <token>`
-- ~80% faster auth validation (no DB lookup)
-- JWTs valid until expiry (logout is client-side only)
 
 ## Code Philosophy
 
@@ -326,7 +331,6 @@ This implementation follows a **lean and pragmatic** approach:
 - JWT validation in middleware (no database lookup)
 - Direct function calls over service layers
 - Standard library JWT patterns
-- ~1,700 lines total for auth system
 - Zero enterprise bloat
 
 See `AGENT.md` for code philosophy details.

--- a/src/auth/middleware.go
+++ b/src/auth/middleware.go
@@ -186,11 +186,15 @@ func GetMember(r *http.Request) *models.Member {
 	return member
 }
 
-// CleanupExpired removes expired auth states
+// CleanupExpired removes expired auth states and sessions
 func CleanupExpired(db data.Database) error {
-	// Delete expired states
 	if err := db.CleanupExpiredAuthStates(); err != nil {
-		slog.Error("failed to delete expired states", slog.String("error", err.Error()))
+		slog.Error("failed to delete expired auth states", slog.String("error", err.Error()))
+		return err
+	}
+
+	if err := db.CleanupExpiredSessions(); err != nil {
+		slog.Error("failed to delete expired sessions", slog.String("error", err.Error()))
 		return err
 	}
 

--- a/src/data/commondb/session.go
+++ b/src/data/commondb/session.go
@@ -1,0 +1,35 @@
+package commondb
+
+import (
+	"errors"
+	"time"
+
+	"github.com/sebastiw/sidan-backend/src/models"
+)
+
+func (d *CommonDatabase) CreateSession(session *models.Session) error {
+	return d.DB.Create(session).Error
+}
+
+func (d *CommonDatabase) GetSession(token string) (*models.Session, error) {
+	var session models.Session
+	result := d.DB.Where("token = ?", token).First(&session)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	if session.ExpiresAt.Before(time.Now()) {
+		d.DB.Delete(&session)
+		return nil, errors.New("session expired")
+	}
+
+	return &session, nil
+}
+
+func (d *CommonDatabase) DeleteSession(token string) error {
+	return d.DB.Where("token = ?", token).Delete(&models.Session{}).Error
+}
+
+func (d *CommonDatabase) CleanupExpiredSessions() error {
+	return d.DB.Where("expires_at < ?", time.Now()).Delete(&models.Session{}).Error
+}

--- a/src/data/database.go
+++ b/src/data/database.go
@@ -62,6 +62,12 @@ type Database interface {
 	GetAuthState(id string) (*models.AuthState, error)
 	DeleteAuthState(id string) error
 	CleanupExpiredAuthStates() error
+
+	// Session operations (web flow refresh tokens)
+	CreateSession(session *models.Session) error
+	GetSession(token string) (*models.Session, error)
+	DeleteSession(token string) error
+	CleanupExpiredSessions() error
 }
 
 func NewDatabase() (Database, error) {

--- a/src/data/mysqldb/session.go
+++ b/src/data/mysqldb/session.go
@@ -1,0 +1,19 @@
+package mysqldb
+
+import "github.com/sebastiw/sidan-backend/src/models"
+
+func (d *MySQLDatabase) CreateSession(session *models.Session) error {
+	return d.CommonDB.CreateSession(session)
+}
+
+func (d *MySQLDatabase) GetSession(token string) (*models.Session, error) {
+	return d.CommonDB.GetSession(token)
+}
+
+func (d *MySQLDatabase) DeleteSession(token string) error {
+	return d.CommonDB.DeleteSession(token)
+}
+
+func (d *MySQLDatabase) CleanupExpiredSessions() error {
+	return d.CommonDB.CleanupExpiredSessions()
+}

--- a/src/models/session.go
+++ b/src/models/session.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+// Session stores a long-lived sidan refresh token issued after web OAuth2 login
+type Session struct {
+	Token        string    `gorm:"primaryKey;size:64"`
+	MemberNumber int64     `gorm:"not null;index"`
+	Email        string    `gorm:"size:255;not null"`
+	Provider     string    `gorm:"size:32;not null"`
+	ExpiresAt    time.Time `gorm:"not null;index"`
+	CreatedAt    time.Time
+}
+
+func (Session) TableName() string {
+	return "oauth2_sessions"
+}

--- a/src/router/auth.go
+++ b/src/router/auth.go
@@ -178,13 +178,28 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("login successful", "provider", authState.Provider, "member", member.Id, "email", userInfo.Email)
 
+	// Issue sidan refresh token (30 day session)
+	refreshToken := auth.GenerateState()
+	session := &models.Session{
+		Token:        refreshToken,
+		MemberNumber: member.Number,
+		Email:        userInfo.Email,
+		Provider:     authState.Provider,
+		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+	}
+	if err := h.db.CreateSession(session); err != nil {
+		slog.Error("failed to store session", "error", err)
+		http.Error(w, "storage error", http.StatusInternalServerError)
+		return
+	}
+
 	// If redirect_uri was provided, redirect with token
 	if authState.RedirectURI != "" {
-		// Build token JSON
 		tokenData := map[string]interface{}{
-			"access_token": jwtToken,
-			"token_type":   "Bearer",
-			"expires_in":   28800, // 8 hours in seconds
+			"access_token":  jwtToken,
+			"refresh_token": refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    28800,
 			"member": map[string]interface{}{
 				"number": member.Number,
 				"email":  userInfo.Email,
@@ -193,7 +208,6 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			"scopes": scopes,
 		}
 
-		// Encode as JSON
 		tokenJSON, err := json.Marshal(tokenData)
 		if err != nil {
 			slog.Error("failed to encode token JSON", "error", err)
@@ -201,12 +215,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// URL-encode the JSON
-		tokenParam := url.QueryEscape(string(tokenJSON))
-
-		// Build redirect URL
-		redirectURL := authState.RedirectURI + "?token=" + tokenParam
-
+		redirectURL := authState.RedirectURI + "?token=" + url.QueryEscape(string(tokenJSON))
 		slog.Info("redirecting to app", "redirect_uri", authState.RedirectURI)
 		http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 		return
@@ -215,9 +224,10 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// No redirect_uri - return JSON response
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"access_token": jwtToken,
-		"token_type":   "Bearer",
-		"expires_in":   28800, // 8 hours in seconds
+		"access_token":  jwtToken,
+		"refresh_token": refreshToken,
+		"token_type":    "Bearer",
+		"expires_in":    28800,
 		"member": map[string]interface{}{
 			"number": member.Number,
 			"email":  userInfo.Email,
@@ -273,39 +283,6 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]bool{"success": true})
-}
-
-// Refresh generates a new JWT token
-// POST /auth/refresh
-// Authorization: Bearer <token>
-func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
-	// Get claims from context
-	claims := auth.GetClaims(r)
-	if claims == nil {
-		http.Error(w, `{"error":"no authentication"}`, http.StatusUnauthorized)
-		return
-	}
-
-	member := auth.GetMember(r)
-	if member == nil {
-		http.Error(w, `{"error":"member not found"}`, http.StatusInternalServerError)
-		return
-	}
-
-	// Generate new JWT with same scopes
-	newToken, err := auth.GenerateJWT(claims.MemberNumber, claims.Email, claims.Scopes, claims.Provider, config.GetJWTSecret())
-	if err != nil {
-		slog.Error("JWT refresh failed", "error", err)
-		http.Error(w, `{"error":"token generation failed"}`, http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"access_token": newToken,
-		"token_type":   "Bearer",
-		"expires_in":   28800, // 8 hours
-	})
 }
 
 // DeviceStart initiates the device authorization flow via the server
@@ -552,6 +529,68 @@ func (h *AuthHandler) DeviceRefresh(w http.ResponseWriter, r *http.Request) {
 			"email":  userInfo.Email,
 		},
 		"scopes": scopes,
+	})
+}
+
+// Token exchanges a sidan refresh token for a new JWT and rotated refresh token
+// POST /auth/refresh
+// Body: {"refresh_token": "..."}
+func (h *AuthHandler) Token(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.RefreshToken == "" {
+		http.Error(w, `{"error":"refresh_token required"}`, http.StatusBadRequest)
+		return
+	}
+
+	session, err := h.db.GetSession(req.RefreshToken)
+	if err != nil {
+		slog.Warn("invalid or expired refresh token", "error", err)
+		http.Error(w, `{"error":"invalid or expired refresh token"}`, http.StatusUnauthorized)
+		return
+	}
+
+	// Rotate: delete old session
+	h.db.DeleteSession(req.RefreshToken)
+
+	member, err := h.db.ReadMemberByNumber(session.MemberNumber)
+	if err != nil || member == nil {
+		http.Error(w, `{"error":"member not found"}`, http.StatusUnauthorized)
+		return
+	}
+
+	scopes := getScopesForMemberType(member)
+	jwtToken, err := auth.GenerateJWT(member.Number, session.Email, scopes, session.Provider, config.GetJWTSecret())
+	if err != nil {
+		slog.Error("JWT generation failed", "error", err)
+		http.Error(w, `{"error":"token generation failed"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Issue new refresh token
+	newRefreshToken := auth.GenerateState()
+	newSession := &models.Session{
+		Token:        newRefreshToken,
+		MemberNumber: member.Number,
+		Email:        session.Email,
+		Provider:     session.Provider,
+		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+	}
+	if err := h.db.CreateSession(newSession); err != nil {
+		slog.Error("failed to store new session", "error", err)
+		http.Error(w, `{"error":"storage error"}`, http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("token refreshed via refresh token", "member", member.Number, "provider", session.Provider)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token":  jwtToken,
+		"refresh_token": newRefreshToken,
+		"token_type":    "Bearer",
+		"expires_in":    28800,
 	})
 }
 

--- a/src/router/auth.go
+++ b/src/router/auth.go
@@ -24,7 +24,7 @@ type AuthHandler struct {
 }
 
 // Login initiates OAuth2 flow
-// GET /auth/login?provider=google&redirect_uri=https://...
+// GET /auth/web/login?provider=google&redirect_uri=https://...
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	provider := r.URL.Query().Get("provider")
 	redirectURI := r.URL.Query().Get("redirect_uri")
@@ -88,7 +88,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 }
 
 // Callback handles OAuth2 callback
-// GET /auth/callback?state=...&code=...
+// GET /auth/web/callback?state=...&code=...
 func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	stateParam := r.URL.Query().Get("state")
 	code := r.URL.Query().Get("code")
@@ -269,7 +269,7 @@ func (h *AuthHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // Logout ends authentication (JWT remains valid until expiry)
-// POST /auth/logout
+// POST /auth/web/logout
 // Authorization: Bearer <token>
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	// Get claims from context
@@ -533,7 +533,7 @@ func (h *AuthHandler) DeviceRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 // Token exchanges a sidan refresh token for a new JWT and rotated refresh token
-// POST /auth/refresh
+// POST /auth/web/refresh
 // Body: {"refresh_token": "..."}
 func (h *AuthHandler) Token(w http.ResponseWriter, r *http.Request) {
 	var req struct {

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -92,9 +92,15 @@ func Mux(db data.Database) http.Handler {
 	r.HandleFunc("/auth/device/poll", authHandler.DevicePoll).Methods("POST", "OPTIONS")
 	r.HandleFunc("/auth/device/refresh", authHandler.DeviceRefresh).Methods("POST", "OPTIONS")
 
+	// Web auth aliases (preferred paths, /auth/{login,callback,refresh,logout} are deprecated)
+	r.HandleFunc("/auth/web/login", authHandler.Login).Methods("GET", "OPTIONS")
+	r.HandleFunc("/auth/web/callback", authHandler.Callback).Methods("GET", "OPTIONS")
+	r.HandleFunc("/auth/web/refresh", authHandler.Token).Methods("POST", "OPTIONS")
+
 	// Auth handlers (authenticated endpoints)
 	r.Handle("/auth/session", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.GetSession))).Methods("GET", "OPTIONS")
 	r.Handle("/auth/logout", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.Logout))).Methods("POST", "OPTIONS")
+	r.Handle("/auth/web/logout", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.Logout))).Methods("POST", "OPTIONS")
 
 	// Start cleanup job (runs every 15 minutes)
 	a.StartCleanupJob(db, 15*time.Minute)

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -87,13 +87,13 @@ func Mux(db data.Database) http.Handler {
 	authHandler := NewAuthHandler(db)
 	r.HandleFunc("/auth/login", authHandler.Login).Methods("GET", "OPTIONS")
 	r.HandleFunc("/auth/callback", authHandler.Callback).Methods("GET", "OPTIONS")
+	r.HandleFunc("/auth/refresh", authHandler.Token).Methods("POST", "OPTIONS")
 	r.HandleFunc("/auth/device/start", authHandler.DeviceStart).Methods("POST", "OPTIONS")
 	r.HandleFunc("/auth/device/poll", authHandler.DevicePoll).Methods("POST", "OPTIONS")
 	r.HandleFunc("/auth/device/refresh", authHandler.DeviceRefresh).Methods("POST", "OPTIONS")
 
-	// Auth handlers - authenticated endpoints
+	// Auth handlers (authenticated endpoints)
 	r.Handle("/auth/session", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.GetSession))).Methods("GET", "OPTIONS")
-	r.Handle("/auth/refresh", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.Refresh))).Methods("POST", "OPTIONS")
 	r.Handle("/auth/logout", authMiddleware.RequireAuth(http.HandlerFunc(authHandler.Logout))).Methods("POST", "OPTIONS")
 
 	// Start cleanup job (runs every 15 minutes)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -847,7 +847,7 @@ paths:
           description: File contents
         404:
           description: File not found
-  /auth/login:
+  /auth/web/login:
     get:
       summary: Initiate OAuth2 web login
       tags:
@@ -870,7 +870,7 @@ paths:
           description: Redirect to provider login page
         400:
           description: Missing or unknown provider
-  /auth/callback:
+  /auth/web/callback:
     get:
       summary: OAuth2 callback — exchanges code for sidan JWT and refresh token
       tags:
@@ -900,47 +900,7 @@ paths:
           description: Missing or invalid state/code
         403:
           description: Email not verified or not registered
-  /auth/session:
-    get:
-      summary: Get current session info
-      tags:
-        - auth
-      security:
-        - BearerAuth: []
-      responses:
-        200:
-          description: Current member and session details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  member:
-                    type: object
-                    properties:
-                      number:
-                        type: integer
-                      name:
-                        type: string
-                        nullable: true
-                      email:
-                        type: string
-                        nullable: true
-                  scopes:
-                    type: array
-                    items:
-                      type: string
-                  provider:
-                    type: string
-                  expires_at:
-                    type: string
-                    format: date-time
-                  issued_at:
-                    type: string
-                    format: date-time
-        401:
-          description: Unauthorized
-  /auth/refresh:
+  /auth/web/refresh:
     post:
       summary: Exchange a sidan refresh token for a new JWT (with token rotation)
       tags:
@@ -966,7 +926,7 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
         401:
           description: Invalid or expired refresh token
-  /auth/logout:
+  /auth/web/logout:
     post:
       summary: Logout (JWT remains valid until expiry — discard client-side)
       tags:
@@ -1092,7 +1052,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: "JWT Bearer token (8h expiry). Web flow: GET /auth/login → GET /auth/callback → returns access_token + refresh_token. Renew with POST /auth/refresh (refresh token rotation, 30d). Device flow: POST /auth/device/start → POST /auth/device/poll → returns access_token + provider refresh_token. Renew with POST /auth/device/refresh."
+      description: "JWT Bearer token (8h expiry). Web flow: GET /auth/web/login → GET /auth/web/callback → returns access_token + refresh_token. Renew with POST /auth/web/refresh (refresh token rotation, 30d). Device flow: POST /auth/device/start → POST /auth/device/poll → returns access_token + provider refresh_token. Renew with POST /auth/device/refresh."
   schemas:
     TokenResponse:
       type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -847,14 +847,282 @@ paths:
           description: File contents
         404:
           description: File not found
+  /auth/login:
+    get:
+      summary: Initiate OAuth2 web login
+      tags:
+        - auth
+      security: []
+      parameters:
+        - name: provider
+          in: query
+          required: true
+          schema:
+            type: string
+            description: OAuth2 provider name (e.g. google, github)
+        - name: redirect_uri
+          in: query
+          description: Where to redirect after login with ?token=<JSON>
+          schema:
+            type: string
+      responses:
+        302:
+          description: Redirect to provider login page
+        400:
+          description: Missing or unknown provider
+  /auth/callback:
+    get:
+      summary: OAuth2 callback — exchanges code for sidan JWT and refresh token
+      tags:
+        - auth
+      security: []
+      parameters:
+        - name: state
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Authentication successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        302:
+          description: Redirect to redirect_uri with ?token=<JSON> if redirect_uri was provided
+        400:
+          description: Missing or invalid state/code
+        403:
+          description: Email not verified or not registered
+  /auth/session:
+    get:
+      summary: Get current session info
+      tags:
+        - auth
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: Current member and session details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member:
+                    type: object
+                    properties:
+                      number:
+                        type: integer
+                      name:
+                        type: string
+                        nullable: true
+                      email:
+                        type: string
+                        nullable: true
+                  scopes:
+                    type: array
+                    items:
+                      type: string
+                  provider:
+                    type: string
+                  expires_at:
+                    type: string
+                    format: date-time
+                  issued_at:
+                    type: string
+                    format: date-time
+        401:
+          description: Unauthorized
+  /auth/refresh:
+    post:
+      summary: Exchange a sidan refresh token for a new JWT (with token rotation)
+      tags:
+        - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - refresh_token
+              properties:
+                refresh_token:
+                  type: string
+      responses:
+        200:
+          description: New JWT and rotated refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        401:
+          description: Invalid or expired refresh token
+  /auth/logout:
+    post:
+      summary: Logout (JWT remains valid until expiry — discard client-side)
+      tags:
+        - auth
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: Logged out
+        401:
+          description: Unauthorized
+  /auth/device/start:
+    post:
+      summary: Start device authorization flow
+      tags:
+        - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - provider
+              properties:
+                provider:
+                  type: string
+                  description: OAuth2 provider name (e.g. google, github)
+      responses:
+        200:
+          description: Device code and user instructions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  session_id:
+                    type: string
+                  user_code:
+                    type: string
+                  verification_url:
+                    type: string
+                  browser_url:
+                    type: string
+                  interval:
+                    type: integer
+                    description: Polling interval in seconds
+                  expires_in:
+                    type: integer
+        400:
+          description: Missing or unknown provider
+  /auth/device/poll:
+    post:
+      summary: Poll for device flow completion
+      tags:
+        - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - session_id
+              properties:
+                session_id:
+                  type: string
+      responses:
+        200:
+          description: Authorization complete — returns JWT and provider refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        202:
+          description: Still pending or slow_down
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [pending, slow_down]
+        401:
+          description: Authorization failed or denied
+  /auth/device/refresh:
+    post:
+      summary: Refresh device flow JWT using stored provider refresh token
+      tags:
+        - auth
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - refresh_token
+                - provider
+              properties:
+                refresh_token:
+                  type: string
+                  description: Provider refresh token (from /auth/device/poll response)
+                provider:
+                  type: string
+                  description: OAuth2 provider name (e.g. google, github)
+      responses:
+        200:
+          description: New JWT and (possibly rotated) provider refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        401:
+          description: Refresh failed — re-authenticate via /auth/device/start
 components:
   securitySchemes:
     BearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: "JWT Bearer token obtained via web OAuth2 flow (GET /auth/login?provider=<provider> → GET /auth/callback) or device flow (POST /auth/device/start → POST /auth/device/poll). Refreshable via POST /auth/device/refresh."
+      description: "JWT Bearer token (8h expiry). Web flow: GET /auth/login → GET /auth/callback → returns access_token + refresh_token. Renew with POST /auth/refresh (refresh token rotation, 30d). Device flow: POST /auth/device/start → POST /auth/device/poll → returns access_token + provider refresh_token. Renew with POST /auth/device/refresh."
   schemas:
+    TokenResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: Sidan JWT (8 hour expiry)
+        refresh_token:
+          type: string
+          description: Refresh token for obtaining a new JWT. Web flow — use POST /auth/token. Device flow — use POST /auth/device/refresh.
+        token_type:
+          type: string
+          example: Bearer
+        expires_in:
+          type: integer
+          example: 28800
+        member:
+          type: object
+          properties:
+            number:
+              type: integer
+            email:
+              type: string
+            name:
+              type: string
+              nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
     APKUploadResult:
       type: object
       properties:


### PR DESCRIPTION
in order to do oauth2 web refresh tokens, we need to store it in db (which is probably why the other models added it in first place).

With these changes the Auth APIs will look like

For device: /auth/device {
- /start - call provider to start the flow for a device token regeneration
- /poll - see if above call completed
- /refresh - create new access-token from refresh-token
}

For web: /auth/web {
- /login - start oauth flow towards provider
- /callback - provider callback after successful auth, will redirect user back to client/application
- /refresh - exchange refresh-token for new access-token
- /logout - deauthenticate provider
}

This PR adds a refresh_token to the /auth/web/callback and /auth/web/refresh APIs.